### PR TITLE
Console init script - consolerc

### DIFF
--- a/src/ape_console/_cli.py
+++ b/src/ape_console/_cli.py
@@ -34,12 +34,14 @@ def load_consolerc(namespace):
         module = SourceFileLoader(consolerc.name[:-3], str(consolerc)).load_module()
 
         # Look for an initrc function
-        if hasattr(module, "initrc"):  # and hasattr(module.initrc, "__call__"):
+        if hasattr(module, "initrc"):
             # Execute functionality with existing console namespace so the
             # script can modify things as it needs
             module.initrc(namespace)
 
-        return {k: getattr(module, k) for k in dir(module) if k != "w" and not k.startswith("_")}
+        return {
+            k: getattr(module, k) for k in dir(module) if k != "initrc" and not k.startswith("_")
+        }
 
 
 def console(project=None, verbose=None, extra_locals=None):


### PR DESCRIPTION
### What I did

This is a proof of concept for a [`consolerc.py` script](https://gist.github.com/mikeshultz/7809b0b14397d44034aeaa4590711091) that can do things like perform common functionality and provide locals you use often when launching a console.

I assume this is not going to fit the normal Ape style, and it does not include any tests.  I'm looking for feedback to see if this is a wanted feature and what might need to be done to make it acceptable for inclusion.

### How I did it

Using Python's `importlib`'s `SourceFileLoader` it loads a module, includes it's non-private symbols in the IPython namespace.  If a function named `initrc()` exists, it will execute it given the namespace created for the console so far.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
